### PR TITLE
Add missing query CleanupDefunctSiloEntriesKey to SQLServer clusterin…

### DIFF
--- a/src/AdoNet/Orleans.Clustering.AdoNet/SQLServer-Clustering.sql
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/SQLServer-Clustering.sql
@@ -277,3 +277,19 @@ WHERE NOT EXISTS
     FROM OrleansQuery oqt
     WHERE oqt.[QueryKey] = 'DeleteMembershipTableEntriesKey'
 );
+
+INSERT INTO OrleansQuery(QueryKey, QueryText)
+SELECT
+    'CleanupDefunctSiloEntriesKey',
+    'DELETE FROM OrleansMembershipTable
+    WHERE DeploymentId = @DeploymentId
+        AND @DeploymentId IS NOT NULL
+        AND IAmAliveTime < @IAmAliveTime
+        AND Status != 3;
+    '
+WHERE NOT EXISTS 
+( 
+    SELECT 1 
+    FROM OrleansQuery oqt
+    WHERE oqt.[QueryKey] = 'CleanupDefunctSiloEntriesKey'
+);


### PR DESCRIPTION
…g script

## Problem:
As written in the issue #8676 and [docs](https://learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/adonet-configuration), to set up ADO.NET clustering using the SQLServer you need to run 2 scripts in sequence:
- [main script for SQLServer](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Shared/SQLServer-Main.sql)
- [clustering script for SQLServer](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Clustering.AdoNet/SQLServer-Clustering.sql)

However, the clustering script does not include the creation of the `CleanupDefunctSiloEntriesKey` query __required__ by the ADO.NET  implementation (Microsoft.Orleans.Clustering.AdoNet) in both the 7.2.x and the 8.0.x versions of Orleans.

Missing query causes an exception at program startup.

## Proposed solution:
Add missing query to clustering sql script.

## Ref: 
- #8676